### PR TITLE
artitalk支持serverURL

### DIFF
--- a/hexo-butterfly-artitalk/index.js
+++ b/hexo-butterfly-artitalk/index.js
@@ -12,6 +12,7 @@ hexo.extend.generator.register('artitalk', function (locals) {
   const data = {
     appId: config.appId,
     appKey: config.appKey,
+    serverURL: config.serverURL,
     option: config.option ? JSON.stringify(config.option) : false,
     js: config.js ? urlFor(config.js) : 'https://cdn.jsdelivr.net/npm/artitalk'
   }

--- a/hexo-butterfly-artitalk/lib/html.pug
+++ b/hexo-butterfly-artitalk/lib/html.pug
@@ -5,6 +5,7 @@ script.
       new Artitalk(Object.assign({
         appId: '#{appId}',
         appKey: '#{appKey}',
+        serverURL: '#{serverURL}'
       }, !{option}))
     }
 


### PR DESCRIPTION
如果使用国内版leancloud会比国际版多一个serverURL配置项，原版artitalk无法显示内容，butterfly版F12中有报错，提示我记不清了，所以修改了插件，经测试能正常使用了。
![artitalk](https://user-images.githubusercontent.com/74824162/122958448-6d3a2300-d3b5-11eb-8329-2545000b48c5.jpg)
